### PR TITLE
Add a docker-build Makefile target

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM golang:onbuild
+
+RUN mkdir /app
+RUN mkdir /build
+
+ADD . /app/
+
+WORKDIR /app
+
+RUN go build -o slappy .

--- a/Makefile
+++ b/Makefile
@@ -20,4 +20,4 @@ test:
 
 docker-build:
 	docker build -t $(DOCKER_TAG) .
-	docker run -it -v `pwd`:/build $(DOCKER_TAG) cp slappy /build
+	docker run -v `pwd`:/build $(DOCKER_TAG) cp slappy /build

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+DOCKER_TAG := slappy-build
+
 all: dependencies build run
 
 build:
@@ -14,3 +16,8 @@ test:
 	.venv/bin/python send14.py
 	.venv/bin/python sendnotify.py
 	pkill slappy
+
+
+docker-build:
+	docker build -t $(DOCKER_TAG) .
+	docker run -it -v `pwd`:/build $(DOCKER_TAG) cp slappy /build


### PR DESCRIPTION
The goal is to be able to build slappy with a single make command that
doesn't require the typical go development filesystem and environment
variables.